### PR TITLE
Fix #65: Separate Profile Updates from Password Management on Admin Edit User Page

### DIFF
--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -943,35 +943,45 @@ class UsersController extends AppController {
         }
     }
 
-    public function admin_edit($id = null) {
-        $this->User->id = $id;
-        if (!$this->User->exists()) {
-            $this->Session->setFlash(__('The user '.$id.' does not exist.'), 'flash_error');
-            $this->redirect('/', null, false);
+    public function admin_edit($id = null) {                                                                                                                             
+            $this->User->id = $id;                                                                                                                                           
+            if (!$this->User->exists()) {                                                                                                                                    
+                $this->Session->setFlash(__('The user '.$id.' does not exist.'), 'flash_error');                                                                             
+                $this->redirect('/', null, false);                                                                                                                           
+            }                                                                                                                                                                
+                    if ($this->request->is('post') || $this->request->is('put')) {                                                                              
+                if (empty($this->request->data['User']['password'])) {                                                                                                       
+                    unset($this->User->validate['password']);                                                                                                                
+                    unset($this->User->validate['confirm_password']);                                                                                                        
+                    unset($this->request->data['User']['password']);                                                                                                         
+                    unset($this->request->data['User']['confirm_password']);                                                                                                 
+                }                                                                                                                                                            
+                                                                                                                                                                             
+                 if ($this->User->save($this->request->data)) {                                                                                                                           
+        $this->Session->setFlash(__('User details updated successfully'), 'flash_success');                                                                                     
+        $this->redirect(array('action' => 'admin_edit', $id));                                                                                                               
+    } else {                                                                                                                                                                                                                                                                        
+        $errors = $this->User->validationErrors;                                                                                                                             
+        $errorMessage = 'Changes could not be saved.';
+        
+        if (!empty($errors['confirm_password'])) {
+            $errorMessage = is_array($errors['confirm_password']) ? implode(', ', $errors['confirm_password']) : $errors['confirm_password'];
+        } elseif (!empty($errors['password'])) {
+            $errorMessage = is_array($errors['password']) ? implode(', ', $errors['password']) : $errors['password'];
         }
-
-        if ($this->request->is('post') || $this->request->is('put')) {
-            // unset($this->User->validate['username']);
-            // unset($this->User->validate['password']);
-            // unset($this->User->validate['confirm_password']);
-            if ($this->User->save($this->request->data)) {
-                $this->Session->setFlash(__('Your details have been updated'), 'flash_success');
-                $this->redirect(array('action' => 'index'));
-            } else {
-                $this->Session->setFlash(__('The user could not be saved. Please, try again.'), 'flash_error');
-            }
-        } else {
-            $this->request->data = $this->User->read(null, $id);
-            unset($this->request->data['User']['password']);
-            unset($this->request->data['User']['confirm_password']);
-        }
-        $groups = $this->User->Group->find('list');
-        $this->set(compact('groups'));
-        $designations = $this->User->Designation->find('list');
-        $this->set(compact('designations'));
-        $counties = $this->User->County->find('list');
-        $this->set(compact('counties'));
-    }
+  
+        $this->Session->setFlash(__($errorMessage), 'flash_error');
+    }                                                                                                                                                          
+            }                                                                                                
+            $this->request->data = $this->User->read(null, $id);                                                                                                             
+            unset($this->request->data['User']['password']);                                                                                                                 
+            unset($this->request->data['User']['confirm_password']);                                                                                                         
+                                                                                                                                                                             
+            $groups = $this->User->Group->find('list');                                                                                                                      
+            $designations = $this->User->Designation->find('list');                                                                                                          
+            $counties = $this->User->County->find('list');                                                                                                                   
+            $this->set(compact('groups', 'designations', 'counties'));                                                                                                       
+        }                    
 
 /**
  * delete method

--- a/app/View/Users/admin_edit.ctp
+++ b/app/View/Users/admin_edit.ctp
@@ -17,98 +17,120 @@
 		//echo $this->element('banner');
 		echo $this->Session->flash();
 		
-		echo $this->Form->create('User', array(
-			'class' => 'form-horizontal', 
-			 'inputDefaults' => array(
-				'div' => array('class' => 'control-group'),
-				'label' => array('class' => 'control-label'),
-				'between' => '<div class="controls">',
-				'after' => '</div>',
-				'class' => '',
-				'format' => array('before', 'label', 'between', 'input', 'after','error'),
-				'error' => array('attributes' => array('class' => 'controls help-block')),
-			 ),		
-		));
-		
-		echo $this->Form->input('id');
-		// print_r( $this->request->data['SadrListOfDrug']);
-	?>
-		  
+		                                                                                                                                          
+                                                                                                                                                                                    
+            echo $this->Form->create('User', array(                                                                                                                                 
+                'class' => 'form-horizontal',                                                                                                                                           
+                'inputDefaults' => array(                                                                                                                                               
+                    'div' => array('class' => 'control-group'),                                                                                                                             
+                    'label' => array('class' => 'control-label'),                                                                                                                           
+                    'between' => '<div class="controls">',                                                                                                                                  
+                    'after' => '</div>',                                                                                                                                                    
+                    'class' => '',                                                                                                                                                          
+                    'format' => array('before', 'label', 'between', 'input', 'after','error'),                                                                                              
+                    'error' => array('attributes' => array('class' => 'controls help-block')),                                                                                              
+                ),                                                                                                                                                                              
+            ));                                                                                                                                                                     
+                                                                                                                                                                                    
+            echo $this->Form->input('id');                                                                                                                                          
+        ?>                                                                                                                                                                      
+                                                                                                                                             
+    <div class="row-fluid">
+        <div class="span4">
+            <fieldset style=" padding: 15px; border-radius: 4px; border: 1px solid #e3e3e3;">
+                <legend style="font-weight: bold; font-size: 16px; margin-bottom: 10px; border-bottom: none !important; border: 0 !important;">Profile Information</legend>
+                <?php
+                    echo $this->Form->input('username', array('label' => array('class' => 'control-label', 'text' => 'Username')));
+                    echo $this->Form->input('name', array('label' => array('class' => 'control-label', 'text' => 'Name')));
+                    echo $this->Form->input('email', array(
+                        'type' => 'email',                
+                        'div' => array('class' => 'control-group required'),
+                        'label' => array('class' => 'control-label required', 'text' => 'E-MAIL ADDRESS')
+                    ));                                                                                                                                                         
+                    echo $this->Form->input('phone_no', array('label' => array('class' => 'control-label', 'text' => 'Phone Number')));
+                    echo $this->Form->input('designation_id', array('label' => array('class' => 'control-label', 'text' => 'Designation')));
+                    echo $this->Form->input('name_of_institution', array('label' => array('class' => 'control-label', 'text' => 'Institution Name')));
+                    echo $this->Form->input('institution_code', array('label' => array('class' => 'control-label', 'text' => 'Institution Code')));
+                    echo $this->Form->input('institution_address', array('label' => array('class' => 'control-label', 'text' => 'Address')));                        
+                    echo $this->Form->input('institution_contact', array('label' => array('class' => 'control-label', 'text' => 'Contacts')));                        
+                    echo $this->Form->input('sponsor_email', array('type' => 'email', 'label' => array('class' => 'control-label', 'text' => 'Company Email')));                            
+                ?>  
+				  <div class="form-actions" style="padding-left: 0; text-align: center; margin-top: 20px; border-top: none; background: transparent;">                                                                               
+                    <?php echo $this->Form->submit('Update Profile', array('class' => 'btn btn-primary', 'div' => false)); ?>                                                               
+                </div>                                                                                                                                                                      
+            </fieldset>    
+        </div>                                                                                                                                                                  
+                                                      
+        <div class="span4">                                                                                                                                                     
+            <fieldset style=" padding: 15px; border-radius: 4px; border: 1px solid #e3e3e3;">                                                                   
+               <legend style="font-weight: bold; font-size: 16px; margin-bottom: 10px; border-bottom: none !important; border: 0 !important;">Access & Permissions</legend>                     
+                <?php                                                                                                                                                                   
+                    echo $this->Form->input('group_id', array('label' => array('class' => 'control-label', 'text' => 'Group/Role')));                                           
+                    echo $this->Form->input('user_type', array(                                                                                                                             
+                        'type' => 'select',
+                        'label' => array('class' => 'control-label', 'text' => 'User Type'),
+                        'empty' => true,                
+                        'options' => ['Market Authority' => 'Market Authority', 'County Pharmacist' => 'County Pharmacist', 'Public Health Program' => 'Public Health Program']                
+                    ));                                                                                                                                                                     
+                    echo $this->Form->input('health_program', array(                                                                                                                        
+                        'type' => 'select',                                                                                                                                                     
+                        'options' => [                                                                                                                                                          
+                            'Malaria program' => 'Malaria program',                                                                                                                                 
+                            'National Vaccines and immunisation program' => 'National Vaccines and immunisation program',                                                                           
+                            'Neglected tropical diseases program' => 'Neglected tropical diseases program',                                                                                         
+                            'MNCAH Priority Medicines' => 'MNCAH Priority Medicines',                                                                                                               
+                            'TB program' => 'TB program',                                                                                                                                           
+                            'NASCOP program' => 'NASCOP program',                                                                                                                                   
+                            'Cancer/Oncology program' => 'Cancer/Oncology program'                                                                                                                  
+                        ],                                                                                                                                                                      
+                        'empty' => true,                                                                                                                                                        
+                        'label' => array('class' => 'control-label', 'text' => 'Public Health Program')                
+                    ));                                                                                                                                                                     
+                    echo $this->Form->input('county_id', array(                                                                                                                             
+                        'label' => array('class' => 'control-label required', 'text' => 'County'),                
+                        'empty' => true,                                                                                                                                                        
+                        'between' => '<div class="controls ui-widget">',                                                                                                        
+                    ));                                                                                                                                                                         
+                    echo $this->Form->input('is_active', array('label' => array('class' => 'control-label', 'text' => 'Is Active?')));                                          
+                    echo $this->Form->input('initial_email', array(
+                        'type' => 'checkbox',
+                        'class' => false,                
+                        'hiddenField' => false,                                                                                                                                                 
+                        'label' => array('class' => 'control-label', 'text' => 'Turn off Notification Email?'),                                                                                 
+                        'between' => '<div class="controls"> <input type="hidden" value="0" id="UserInitialEmail_" name="data[User][initial_email]"><label class="checkbox"     
+  style="color:#C09853; font-weight:normal">',                                                                                                                               
+                       'after' => 'Turn on/off the initial email sent after you create a report. Only the successful submit confirmation
+																email will be sent. Check to turn off. Changes will take effect on next login.</label> </div>',                                                                                                    
+                    ));                                                                                                                                                                     
+                ?> 
+				  <div class="form-actions" style="padding-left: 0; text-align: center; margin-top: 20px; border-top: none; background: transparent;">                                                                            
+                    <?php echo $this->Form->submit('Submit', array('class' => 'btn btn-success', 'div' => false)); ?>                                                           
+                </div>                                                                                                                                                                         
+            </fieldset>                                                                                                                                                             
+        </div>                                                                                                                                                                  
+                                                                                                                                                                
+        <div class="span4">                                                                                                                                                     
+            <fieldset style=" padding: 15px; border-radius: 4px; border: 1px solid #e3e3e3;">    
+              <legend style="font-weight: bold; font-size: 16px; margin-bottom: 10px; border-bottom: none !important; border: 0 !important;">Security</legend>                                   
+                <?php                                                                                                                                                                   
+                    echo $this->Form->input('password', array(            
+                        'required' => false,                                                                                                                                                    
+                        'value' => '',                
+                        'label' => array('class' => 'control-label', 'text' => 'New Password')                                                                                                  
+                    ));                        
+                    echo $this->Form->input('confirm_password', array(                                                                                                          
+                        'type' => 'password',                                                                                                                                   
+                        'required' => false,
+                        'label' => array('class' => 'control-label', 'text' => 'Confirm New Password')
+                    ));
+                ?>
+				  <div class="form-actions" style="padding-left: 0; text-align: center; margin-top: 20px; border-top: none; background: transparent;">                                                                              
+                    <?php echo $this->Form->submit('Change Password', array('class' => 'btn btn-danger', 'div' => false)); ?>                                                               
+                </div> 
+            </fieldset>
+        </div>
 
-	
-	<div class="row-fluid">
-		<div class="span6">
-			<?php
-				echo $this->Form->input('username', array('label' => array('class' => 'control-label', 'text' => 'Username'),));
-				// echo $this->Form->input('password', array('label' => array('class' => 'control-label', 'text' => 'Password'),));			
-				// echo $this->Form->input('confirm_password', array(
-						// 'type' => 'password',
-						// 'label' => array('class' => 'control-label', 'text' => 'Confirm Password'), ));
-				echo $this->Form->input('name', array('label' => array('class' => 'control-label', 'text' => 'Name'),));			
-				echo $this->Form->input('email', array(
-					'type' => 'email', 
-					'div' => array('class' => 'control-group required'),
-					'label' => array('class' => 'control-label required', 'text' => 'E-MAIL ADDRESS')
-				));
-				echo $this->Form->input('phone_no', array('label' => array('class' => 'control-label', 'text' => 'Phone Number'),));			
-				echo $this->Form->input('group_id', array('label' => array('class' => 'control-label', 'text' => 'Group/Role'), ));		
-				echo $this->Form->input('password', array('label' => array('class' => 'control-label required', 'text' => 'New Password'.' <span style="color:red;">*</span>'),));			
-				echo $this->Form->input('confirm_password', array(
-						'type' => 'password',
-						'label' => array('class' => 'control-label required', 'text' => 'Confirm New Password'.' <span style="color:red;">*</span>'), ));						
-				echo $this->Form->input('is_active', array('label' => array('class' => 'control-label', 'text' => 'Is Active?'), ));		
-				// echo $this->Form->input('is_admin', array('label' => array('class' => 'control-label', 'text' => 'Is Admin?'), ));		
-				echo $this->Form->input('user_type', array('type' => 'select', 'label' => array('class' => 'control-label', 'text' => 'User Type'),
-						'empty' => true, 'options' => ['Market Authority' => 'Market Authority', 'County Pharmacist' => 'County Pharmacist', 'Public Health Program' => 'Public Health Program']));
-				echo $this->Form->input('sponsor_email', array('type' => 'email', 'label' => array('class' => 'control-label', 'text' => 'Company email'),));
-				echo $this->Form->input('health_program', array( 'type' => 'select', 'options' => ['Malaria program' => 'Malaria program', 'National Vaccines and immunisation program' => 'National Vaccines and immunisation program', 
-										'Neglected tropical diseases program' => 'Neglected tropical diseases program', 'MNCAH Priority Medicines' => 'MNCAH Priority Medicines', 'TB program' => 'TB program', 
-										'NASCOP program' => 'NASCOP program', 'Cancer/Oncology program' => 'Cancer/Oncology program'], 'empty' => true,
-										'label' => array('class' => 'control-label', 'text' => 'Public Health Program')));
-				?>
-		</div><!--/span-->
-		<div class="span6">
-			<?php
-				// echo $this->Form->input('group_id', array('label' => array('class' => 'control-label', 'text' => 'Group'), ));		
-				echo $this->Form->input('designation_id', array('label' => array('class' => 'control-label', 'text' => 'Designation'),));	
-				echo $this->Form->input('name_of_institution', array(
-					'label' => array('class' => 'control-label', 'text' => 'Name of Institution'),
-					'after'=>'<p class="help-block"> Start typing and suggestions will appear </p></div>',
-				));	
-				echo $this->Form->input('institution_code', array(
-					'label' => array('class' => 'control-label', 'text' => 'Institution Code'),
-					'after'=>'<p class="help-block"> Start typing and suggestions will appear </p></div>',
-				));	
-				echo $this->Form->input('institution_address', array('label' => array('class' => 'control-label', 'text' => 'Institution Address'),));			
-				echo $this->Form->input('institution_contact', array('label' => array('class' => 'control-label', 'text' => 'Institution Contacts'),));			
-				echo $this->Form->input('county_id', array(
-									'label' => array('class' => 'control-label required', 'text' => 'County '), 
-									'empty' => true, 'between' => '<div class="controls ui-widget">',
-								));	
-				echo $this->Form->input('initial_email', array(
-													'type' => 'checkbox',  'class' => false, 'hiddenField' => false, 
-													'label' => array('class' => 'control-label', 'text' => 'Turn off Notification Email?'),
-													'between' => '<div class="controls"> <input type="hidden" value="0" id="UserInitialEmail_" name="data[User][initial_email]">
-																	<label class="checkbox" style="color:#C09853; font-weight:normal">',
-													'after' => 'Turn on/off the initial email sent after you create a report. Only the successful submit confirmation
-																email will be sent. Check to turn off. Changes will take effect on next login.</label> </div>',));
-			?>
-		</div><!--/span-->
-	</div><!--/row-->
-	 <hr>
-	
-	
-	
-	<?php echo $this->Form->end(array(
-		'label' => 'Submit',
-		'value' => 'Save',
-		'class' => 'btn btn-primary',
-		'id' => 'SadrSaveChanges',  
-		'div' => array(
-			'class' => 'form-actions',
-		)
-	));?>
-	
+    </div>         
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
This PR refactors the Admin > Edit User page by separating profile management from password management. Administrators can now update user profile information without being required to enter a new password, while password changes remain available as a separate action within the same page.

**Changes**

**Profile Information**
Separated personal information into its own section.
Allows profile details to be updated independently.
**Access & Permissions**
Isolated role, user type, public health program, county, and institution management.
Enables administrators to update access settings without affecting other user data.
**Security**
Moved password management into a dedicated section.
Password fields are only validated when a password change is requested.
Existing passwords remain unchanged during profile or permission updates.

**Why**
Previously, administrators were required to enter a new password whenever they updated profile attributes such as a user's role, user type, public health program, or county. This created an unnecessary dependency between unrelated administrative tasks and increased the risk of accidental password resets.
Separating these workflows improves usability, simplifies validation logic, and provides a cleaner foundation for future account security features.

**Testing**
Verified profile information can be updated without entering a password.
Verified roles, user type, public health program, county, and institution can be updated independently.
Verified password changes only validate the security section.
Verified existing passwords remain unchanged during non-security updates.
Verified the updated layout is responsive across desktop and mobile devices.

**Screenshots**
**Before**
<img width="1342" height="746" alt="Screenshot From 2026-08-03 08-28-48" src="https://github.com/user-attachments/assets/e9d122e9-8fb4-489f-a7ef-577be107a2fd" />


**After**
<img width="1352" height="768" alt="Screenshot From 2026-08-03 11-12-57" src="https://github.com/user-attachments/assets/c0e92d13-43a3-44dd-98c0-8b639aceb83a" />
