### PR TITLE
Fix#70: Make medication product fields mandatory

### DIFF
--- a/app/Model/MedicationProduct.php
+++ b/app/Model/MedicationProduct.php
@@ -40,19 +40,33 @@ class MedicationProduct extends AppModel {
                 'message'  => 'Please provide product no. 2 (error)'
             ),
         ),
-        // 'dosage_i' => array(
-        //     'notBlank' => array(
-        //         'rule'     => 'notBlank',
-        //         'required' => true,
-        //         'message'  => 'Please provide dose, frequence... 1 (error)'
-        //     ),
-        // ),
-        // 'dosage_ii' => array(
-        //     'notBlank' => array(
-        //         'rule'     => 'notBlank',
-        //         'required' => true,
-        //         'message'  => 'Please provide dose, frequency... 2 (intended)'
-        //     ),
-        // ),
+          'product_name_i' => array(                                                                                                                                       
+                'notBlank' => array(                                                                                                                                         
+                    'rule'     => 'notBlank',                                                                                                                                
+                    'required' => true,                                                                                                                                      
+                    'message'  => 'Please provide Brand/Product Name for product no. 1 (intended)'                                                                           
+                ),                                                                                                                                                           
+            ),                                                                                                                                                               
+            'product_name_ii' => array(                                                                                                                                      
+                'notBlank' => array(                                                                                                                                         
+                    'rule'     => 'notBlank',                                                                                                                                
+                    'required' => true,                                                                                                                                      
+                    'message'  => 'Please provide Brand/Product Name for product no. 2 (error)'                                                                              
+                ),                                                                                                                                                           
+            ),
+       'dosage_i' => array(                                                                                                                                             
+                'notBlank' => array(                                                                                                                                         
+                    'rule'     => 'notBlank',                                                                                                                                
+                    'required' => true,                                                                                                                                      
+                    'message'  => 'Please provide the dose, frequency, duration, route for product no. 1 (intended)'                                                         
+                ),                                                                                                                                                           
+            ),                                                                                                                                                               
+            'dosage_ii' => array(                                                                                                                                            
+                'notBlank' => array(                                                                                                                                         
+                    'rule'     => 'notBlank',                                                                                                                                
+                    'required' => true,                                                                                                                                      
+                    'message'  => 'Please provide the dose, frequency, duration, route for product no. 2 (error)'                                                            
+                ),                                                                                                                                                           
+            ),       
     );
 }

--- a/app/View/Elements/multi/list_of_products.ctp
+++ b/app/View/Elements/multi/list_of_products.ctp
@@ -44,7 +44,7 @@
                     <td><?php
                           echo $this->Form->input('MedicationProduct.'.$i.'.id');                          
                         ?>
-                        Generic name (active ingredient)
+                        Generic name (active ingredient) <span style="color:red;">*</span>                                                                               
                     </td>
                     <td>
                         <?php
@@ -67,7 +67,7 @@
                     </td>
                   </tr>
                   <tr>
-                    <td>Brand/ Product Name</td>
+                    <td>Brand/ Product Name<span style="color:red;">*</span></td>
                     <td>
                         <?php
                           echo $this->Form->input('MedicationProduct.'.$i.'.product_name_i', array(

--- a/app/webroot/js/list_of_products.js
+++ b/app/webroot/js/list_of_products.js
@@ -38,7 +38,7 @@ $(function() {
         var trWrapper = '\
                   <tr>\
                     <td rowspan="8" class="sailor">{i2}</td>\
-                    <td><input type="hidden" name="data[MedicationProduct][{i}][id]" class="" id="MedicationProduct{i}Id"> Generic name (active ingredient) </td>\
+                    <td><input type="hidden" name="data[MedicationProduct][{i}][id]" class="" id="MedicationProduct{i}Id"> Generic name (active ingredient) <span style="color:red;">*</span> </td>\
                     <td>\
                         <div class="control-group"><input name="data[MedicationProduct][{i}][generic_name_i]" class="span11 autosave-ignore" maxlength="255" type="text" id="MedicationProduct{i}GenericNameI"></div> </td> \
                     <td>\
@@ -47,7 +47,7 @@ $(function() {
                         <button type="button" class="btn btn-danger btn-sm remove-product" value=""> <i class="icon-minus"></i> </button></td>\
                   </tr>\
                   <tr>\
-                    <td>Brand/ Product Name</td>\
+                    <td>Brand/ Product Name <span style="color:red;">*</span></td>\
                     <td>\
                         <div class="control-group"><input name="data[MedicationProduct][{i}][product_name_i]" class="span11 autosave-ignore" maxlength="255" type="text" id="MedicationProduct{i}ProductNameI"></div> </td>\
                     <td>\


### PR DESCRIPTION
This PR makes key medication product fields mandatory in the Medication Product module to improve data completeness and prevent incomplete medication records from being submitted.

**Changes Made**

- Made **Generic Name** mandatory.
- Made **Brand/Product Name** mandatory.
- Made **Dose, frequency, duration, route ** mandatory.
- Added validation to prevent submission when any of the required fields are left blank.

**Expected Behaviour**
Users should not be able to submit a medication product record if any of the required fields are empty.

**Testing**

- Tested the medication product form with all required fields populated.
- Tested submission with individual required fields left blank.
- Confirmed that incomplete records are prevented from being submitted.
- Confirmed that valid medication product records can still be submitted successfully.


